### PR TITLE
Update settings.html

### DIFF
--- a/pages/settings.html
+++ b/pages/settings.html
@@ -21,4 +21,7 @@
         Themes:
         <a href="https://github.com/catppuccin/catppuccin">Catppuccin</a>
     </li>
+    <li>
+        <a href="https://github.com/Axilotl17" {% include link.html %}>Axilotl</a>, for being literally the best
+    </li>
 </ul>


### PR DESCRIPTION
adding for parity to older version; new users may be confused that this is missing from this version, as they grew accustomed to it [being on the old website](https://github.com/Bright-Shard/old-gh-pages-site/pull/1). 